### PR TITLE
Upgrade to ClamAV v102

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 *.out
 
 build/
+.DS_Store

--- a/build/build.sh
+++ b/build/build.sh
@@ -15,8 +15,11 @@ yum install -y cpio yum-utils zip
 # extract binaries for clamav, json-c, pcre
 mkdir -p /tmp/build
 pushd /tmp/build
-yumdownloader -x \*i686 --archlist=x86_64 clamav clamav-lib clamav-update json-c pcre2 libxml2 bzip2-libs libtool-ltdl xz-libs
+
+curl -L --output clamav-0.102.4-14050.el7.art.x86_64.rpm http://www6.atomicorp.com/channels/atomic/centos/7/x86_64/RPMS/clamav-0.102.4-14050.el7.art.x86_64.rpm
 rpm2cpio clamav-0*.rpm | cpio -vimd
+
+yumdownloader -x \*i686 --archlist=x86_64 clamav clamav-lib clamav-update json-c pcre2 libxml2 bzip2-libs libtool-ltdl xz-libs libprelude gnutls nettle libcurl libnghttp2 libidn2 libssh2 openldap libffi krb5-libs keyutils-libs libunistring cyrus-sasl-lib nss nspr libselinux openssl-libs libcrypt
 rpm2cpio clamav-lib*.rpm | cpio -vimd
 rpm2cpio clamav-update*.rpm | cpio -vimd
 rpm2cpio json-c*.rpm | cpio -vimd
@@ -25,6 +28,25 @@ rpm2cpio libxml2*.rpm | cpio -vimd
 rpm2cpio bzip2-libs*.rpm | cpio -vimd
 rpm2cpio libtool-ltdl*.rpm | cpio -vimd
 rpm2cpio xz-libs*.rpm | cpio -vimd
+rpm2cpio libprelude*.rpm | cpio -vimd
+rpm2cpio gnutls*.rpm | cpio -vimd
+rpm2cpio nettle*.rpm | cpio -vimd
+rpm2cpio libcurl*.rpm | cpio -vimd
+rpm2cpio libnghttp2*.rpm | cpio -vimd
+rpm2cpio libidn2*.rpm | cpio -vimd
+rpm2cpio libssh2*.rpm | cpio -vimd
+rpm2cpio openldap*.rpm | cpio -vimd
+rpm2cpio libffi*.rpm | cpio -vimd
+rpm2cpio krb5-libs*.rpm | cpio -vimd
+rpm2cpio keyutils-libs*.rpm | cpio -vimd
+rpm2cpio libunistring*.rpm | cpio -vimd
+rpm2cpio cyrus-sasl-lib*.rpm | cpio -vimd
+rpm2cpio nss*.rpm | cpio -vimd
+rpm2cpio nspr*.rpm | cpio -vimd
+rpm2cpio libselinux*.rpm | cpio -vimd
+rpm2cpio openssl-libs*.rpm | cpio -vimd
+rpm2cpio libcrypt*.rpm | cpio -vimd
+
 # reset the timestamps so that we generate a reproducible zip file where
 # running with the same file contents we get the exact same hash even if we
 # run the same build on different days
@@ -35,8 +57,11 @@ mkdir -p bin
 mkdir -p lib
 
 cp /tmp/build/usr/bin/clamscan /tmp/build/usr/bin/freshclam bin/.
-cp /tmp/build/usr/lib64/* lib/.
+cp -R /tmp/build/usr/lib64/* lib/.
+cp -R /tmp/build/lib64/* lib/.
 cp freshclam.conf bin/freshclam.conf
+
+mv lib/libcrypt-2.26.so lib/libcrypt.so.1
 
 zip -r9 /opt/app/lambda_layer.zip bin
 zip -r9 /opt/app/lambda_layer.zip lib


### PR DESCRIPTION
Running the build script created a package with ClamAV >= v102. This PR adds missing dependencies so that this package will run in a lambda layer running Node 12.