### PR TITLE
update build script to ClamAV 103.3 LTS release

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -17,11 +17,11 @@ mkdir -p /tmp/build
 pushd /tmp/build
 
 # Download the clamav package that includes unrar
-curl -L --output clamav-0.102.4-14050.el7.art.x86_64.rpm http://www6.atomicorp.com/channels/atomic/centos/7/x86_64/RPMS/clamav-0.102.4-14050.el7.art.x86_64.rpm
+curl -L --output clamav-0.103.3-22187.el7.art.x86_64.rpm http://www6.atomicorp.com/channels/atomic/centos/7/x86_64/RPMS/clamav-0.103.3-22187.el7.art.x86_64.rpm
 rpm2cpio clamav-0*.rpm | cpio -vimd
 
 # Download libcrypt.so.1
-curl -L --output glibc-2.17-307.el7.1.x86_64.rpm http://mirror.centos.org/centos/7/os/x86_64/Packages/glibc-2.17-307.el7.1.x86_64.rpm
+curl -L --output glibc-2.17-317.el7.x86_64.rpm http://mirror.centos.org/centos/7/os/x86_64/Packages/glibc-2.17-317.el7.x86_64.rpm
 rpm2cpio glibc*.rpm | cpio -vimd
 
 # Download other package dependencies


### PR DESCRIPTION
This updates build.sh minimally to install ClamAV version 0.103.3 instead of 0.102.4. 0.102x has been end of life'd and 103x is an LTS release, supported through October of next year. 