### PR TITLE
Add CompressLocalDatabase yes to the freshclam conf

### DIFF
--- a/build/freshclam.conf
+++ b/build/freshclam.conf
@@ -1,1 +1,2 @@
 DatabaseMirror database.clamav.net
+CompressLocalDatabase yes


### PR DESCRIPTION
CompressLocalDatabase should force freshclam to prefer the compressed versions of the defintion files, this should keep our upload/download times to a minimum and may help alleviate the issue we’ve been having with the avDefintionDownload lambda. 